### PR TITLE
本番環境のAPI URLを明示する設定を追加

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,14 @@
+# 本番環境用の環境変数
+# Next.js
+NEXTAUTH_URL=https://quiz-frontend-974259457412.asia-northeast1.run.app
+NEXTAUTH_SECRET=__SET_VIA_CLOUD_RUN_ENV__
+AUTH_TRUST_HOST=true
+
+# Google OAuth (本番用の値に置き換えてください)
+GOOGLE_CLIENT_ID=__SET_VIA_CLOUD_RUN_ENV__
+GOOGLE_CLIENT_SECRET=__SET_VIA_CLOUD_RUN_ENV__
+
+# API URLs (本番環境用)
+NEXT_PUBLIC_API_URL=https://quiz-backend-974259457412.asia-northeast1.run.app/api
+NEXT_PUBLIC_API_URL_BROWSER=https://quiz-backend-974259457412.asia-northeast1.run.app/api
+BACKEND_URL=https://quiz-backend-974259457412.asia-northeast1.run.app/api

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.production
 
 # vercel
 .vercel


### PR DESCRIPTION
Next.jsの本番ビルドでCloud RunのバックエンドURLを参照できるように、.env.productionを追加し、NEXT_PUBLIC_API_URL/BACKEND_URLを設定しました。また、.gitignoreを調整して.env.productionのみリポジトリに含めるようにしました。