### PR TITLE
Fix: 本番フロントのAPIベースURLから重複する /api を削除

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -9,6 +9,6 @@ GOOGLE_CLIENT_ID=__SET_VIA_CLOUD_RUN_ENV__
 GOOGLE_CLIENT_SECRET=__SET_VIA_CLOUD_RUN_ENV__
 
 # API URLs (本番環境用)
-NEXT_PUBLIC_API_URL=https://quiz-backend-974259457412.asia-northeast1.run.app/api
-NEXT_PUBLIC_API_URL_BROWSER=https://quiz-backend-974259457412.asia-northeast1.run.app/api
-BACKEND_URL=https://quiz-backend-974259457412.asia-northeast1.run.app/api
+NEXT_PUBLIC_API_URL=https://quiz-backend-974259457412.asia-northeast1.run.app
+NEXT_PUBLIC_API_URL_BROWSER=https://quiz-backend-974259457412.asia-northeast1.run.app
+BACKEND_URL=https://quiz-backend-974259457412.asia-northeast1.run.app


### PR DESCRIPTION
フロント側での二重/api付与により /api/api/... となっていたため、.env.production の NEXT_PUBLIC_API_URL/NEXT_PUBLIC_API_URL_BROWSER/BACKEND_URL から末尾の /api を取り除きました。