### PR TITLE
security: ハードコードされた個人メールアドレスを削除

### DIFF
--- a/backend/quiz/views.py
+++ b/backend/quiz/views.py
@@ -2839,7 +2839,10 @@ class StudentVocabReportView(APIView):
         ]
         body = "\n".join(body_lines)
 
-        email_to = getattr(settings, "VOCAB_REPORT_EMAIL_TO", "adm19fk@gmail.com")
+        email_to = getattr(settings, "VOCAB_REPORT_EMAIL_TO", None)
+        if not email_to:
+            logger.warning("VOCAB_REPORT_EMAIL_TO is not configured")
+            return Response({"detail": "Email reporting is not configured"}, status=500)
         send_mail(
             subject,
             body,

--- a/backend/quiz_backend/settings.py
+++ b/backend/quiz_backend/settings.py
@@ -260,7 +260,7 @@ EMAIL_HOST_PASSWORD = config('EMAIL_HOST_PASSWORD', default='')
 DEFAULT_FROM_EMAIL = config('DEFAULT_FROM_EMAIL', default='noreply@example.com')
 
 # Vocabulary report settings
-VOCAB_REPORT_EMAIL_TO = config('VOCAB_REPORT_EMAIL_TO', default='adm19fk@gmail.com')
+VOCAB_REPORT_EMAIL_TO = config('VOCAB_REPORT_EMAIL_TO', default=None)
 VOCAB_REPORT_SLACK_WEBHOOK_URL = config('VOCAB_REPORT_SLACK_WEBHOOK_URL', default=None)
 
 # Environment

--- a/test_whitelist.py
+++ b/test_whitelist.py
@@ -17,8 +17,8 @@ def test_whitelist_function():
         
         # テストケース
         test_emails = [
-            'kentaf0926@gmail.com',
-            'KENTAF0926@GMAIL.COM',  # 大文字小文字のテスト
+            'test@example.com',
+            'TEST@EXAMPLE.COM',  # 大文字小文字のテスト
             'other@example.com',
             '',
             None


### PR DESCRIPTION
- test_whitelist.py: テストメールアドレスを example.com に変更
- backend/quiz/views.py: デフォルトメールアドレスを削除し環境変数依存に
- backend/quiz_backend/settings.py: VOCAB_REPORT_EMAIL_TO のデフォルト値を None に変更
- セキュリティ向上: 個人情報のハードコードを排除