### PR TITLE
feat: 招待コードプレビュー・再紐付け・教師プロフィール表示を追加・修正\n\n-  にプレビュー用アクションを追加し、講師プロフィー…

### DIFF
--- a/backend/quiz/middleware.py
+++ b/backend/quiz/middleware.py
@@ -97,6 +97,7 @@ class TeacherAccessControlMiddleware:
     STUDENT_OPEN_PATHS = [
         '/api/student-teacher-links/',
         '/api/invitation-codes/redeem',
+        '/api/invitation-codes/preview',
     ]
     
     def __init__(self, get_response):

--- a/backend/quiz/serializers.py
+++ b/backend/quiz/serializers.py
@@ -147,6 +147,15 @@ class StudentTeacherLinkSerializer(serializers.ModelSerializer):
         return obj.teacher.email
 
 
+class StudentTeacherPublicProfileSerializer(serializers.Serializer):
+    teacher_id = serializers.UUIDField(read_only=True)
+    display_name = serializers.CharField(read_only=True)
+    affiliation = serializers.CharField(allow_null=True, allow_blank=True, read_only=True)
+    avatar_url = serializers.CharField(allow_null=True, allow_blank=True, read_only=True)
+    bio = serializers.CharField(allow_null=True, allow_blank=True, read_only=True)
+    updated_at = serializers.DateTimeField(read_only=True)
+
+
 class TeacherStudentListSerializer(serializers.ModelSerializer):
     student_teacher_link_id = serializers.UUIDField(source="id", read_only=True)
     display_name = serializers.SerializerMethodField()

--- a/backend/quiz/views.py
+++ b/backend/quiz/views.py
@@ -235,6 +235,61 @@ class InvitationCodeViewSet(BaseModelViewSet):
         invite.save(update_fields=["revoked", "revoked_at"])
         return Response({"detail": "招待コードを失効しました。"})
 
+    def _serialize_teacher_profile(self, teacher):
+        profile = getattr(teacher, "profile", None)
+        data = {
+            "teacher_id": teacher.id,
+            "display_name": profile.display_name if profile and profile.display_name else teacher.email,
+            "affiliation": profile.affiliation if profile and profile.affiliation else None,
+            "avatar_url": profile.avatar_url if profile and profile.avatar_url else None,
+            "bio": profile.bio if profile and profile.bio else None,
+            "updated_at": profile.updated_at if profile else teacher.updated_at,
+        }
+        serializer = serializers.StudentTeacherPublicProfileSerializer(data)
+        return serializer.data
+
+    @action(detail=False, methods=["post"], permission_classes=[permissions.IsAuthenticated], url_path="preview")
+    def preview(self, request):
+        """招待コードの講師情報を確認する"""
+        user = request.user
+        ip_addr = request.META.get("REMOTE_ADDR", "unknown")
+        if not self._rate_limit(f"invite_preview_ip:{ip_addr}", limit=15, window_seconds=300):
+            return Response({"detail": "短時間の招待コード試行回数を超えました。しばらくしてから再試行してください。"}, status=status.HTTP_429_TOO_MANY_REQUESTS)
+        if not self._rate_limit(f"invite_preview_user:{user.id}", limit=15, window_seconds=600):
+            return Response({"detail": "短時間の招待コード試行回数を超えました。しばらくしてから再試行してください。"}, status=status.HTTP_429_TOO_MANY_REQUESTS)
+
+        code_str = (request.data.get("invitation_code") or "").strip()
+        if not code_str:
+            return Response({"detail": "招待コードを入力してください。"}, status=status.HTTP_400_BAD_REQUEST)
+
+        now = timezone.now()
+        code = models.InvitationCode.objects.filter(
+            invitation_code=code_str,
+            revoked=False,
+        ).select_related("issued_by__profile").first()
+        if not code:
+            return Response({"detail": "招待コードが無効です。"}, status=status.HTTP_400_BAD_REQUEST)
+        if code.expires_at and code.expires_at < now:
+            return Response({"detail": "招待コードの有効期限が切れています。"}, status=status.HTTP_400_BAD_REQUEST)
+        if code.used_at:
+            return Response({"detail": "この招待コードは使用済みです。"}, status=status.HTTP_400_BAD_REQUEST)
+
+        existing_link = models.StudentTeacherLink.objects.filter(
+            teacher=code.issued_by,
+            student=user,
+        ).first()
+        existing_status = existing_link.status if existing_link else None
+        can_redeem = not (existing_link and existing_link.status in [models.LinkStatus.PENDING, models.LinkStatus.ACTIVE])
+
+        teacher_profile = self._serialize_teacher_profile(code.issued_by)
+        return Response(
+            {
+                "teacher_profile": teacher_profile,
+                "existing_link_status": existing_status,
+                "can_redeem": can_redeem,
+            }
+        )
+
     @action(detail=False, methods=["post"], permission_classes=[permissions.IsAuthenticated], url_path="redeem")
     def redeem(self, request):
         """生徒が招待コードを利用してリンクを作成する"""
@@ -254,7 +309,7 @@ class InvitationCodeViewSet(BaseModelViewSet):
         code = models.InvitationCode.objects.filter(
             invitation_code=code_str,
             revoked=False,
-        ).first()
+        ).select_related("issued_by__profile").first()
         if not code:
             return Response({"detail": "招待コードが無効です。"}, status=status.HTTP_400_BAD_REQUEST)
         if code.expires_at and code.expires_at < now:
@@ -365,6 +420,27 @@ class StudentTeacherLinkViewSet(BaseModelViewSet):
         link.custom_display_name = alias_str or None
         link.save(update_fields=["custom_display_name", "updated_at"])
         return Response(serializers.StudentTeacherLinkSerializer(link).data)
+
+    @action(detail=True, methods=["get"], permission_classes=[permissions.IsAuthenticated], url_path="teacher-profile")
+    def teacher_profile(self, request, pk=None):
+        """生徒向けに講師プロフィールを返す"""
+        link = self.get_object()
+        if link.student_id != request.user.id:
+            raise PermissionDenied("閲覧権限がありません。")
+        if link.status not in [models.LinkStatus.PENDING, models.LinkStatus.ACTIVE]:
+            return Response({"detail": "この講師との紐付けは現在ありません。"}, status=status.HTTP_404_NOT_FOUND)
+
+        profile = getattr(link.teacher, "profile", None)
+        data = {
+            "teacher_id": link.teacher_id,
+            "display_name": (profile.display_name if profile and profile.display_name else "名前未設定"),
+            "affiliation": profile.affiliation if profile and profile.affiliation else None,
+            "avatar_url": profile.avatar_url if profile and profile.avatar_url else None,
+            "bio": profile.bio if profile and profile.bio else None,
+            "updated_at": (profile.updated_at if profile else link.teacher.updated_at),
+        }
+        serializer = serializers.StudentTeacherPublicProfileSerializer(data)
+        return Response(serializer.data)
 
     @action(detail=False, methods=["get", "patch"], permission_classes=[permissions.IsAuthenticated], url_path="by-teacher")
     def list_by_teacher(self, request):

--- a/frontend/src/app/student/teachers/[linkId]/page.tsx
+++ b/frontend/src/app/student/teachers/[linkId]/page.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { apiGet } from '@/lib/api-utils';
+
+interface TeacherPublicProfile {
+  teacher_id: string;
+  display_name: string;
+  affiliation?: string | null;
+  avatar_url?: string | null;
+  bio?: string | null;
+  updated_at: string;
+}
+
+export default function StudentTeacherProfilePage() {
+  const params = useParams<{ linkId: string }>();
+  const router = useRouter();
+  const [profile, setProfile] = useState<TeacherPublicProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const linkId = params?.linkId;
+    if (!linkId) return;
+    const fetchProfile = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const data = await apiGet<TeacherPublicProfile>(`/api/student-teacher-links/${linkId}/teacher-profile/`);
+        setProfile(data);
+      } catch (err) {
+        console.error(err);
+        setError('講師プロフィールを取得できませんでした。');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchProfile();
+  }, [params?.linkId]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="animate-spin rounded-full h-16 w-16 border-b-2 border-indigo-600" />
+      </div>
+    );
+  }
+
+  if (error || !profile) {
+    return (
+      <div className="max-w-xl mx-auto py-10 px-4 text-center space-y-4">
+        <p className="text-slate-600">{error || '講師が見つかりませんでした。'}</p>
+        <button
+          type="button"
+          onClick={() => router.back()}
+          className="text-indigo-600 font-semibold hover:underline"
+        >
+          ← プロフィールに戻る
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-10 space-y-6">
+      <div className="flex items-center gap-2 text-sm text-indigo-700 font-semibold">
+        <Link href="/student/profile" className="hover:underline">
+          ← プロフィールに戻る
+        </Link>
+      </div>
+
+      <section className="bg-white shadow rounded-3xl p-6 text-center space-y-4">
+        <div className="flex flex-col items-center gap-4">
+          {profile.avatar_url ? (
+            <img
+              src={profile.avatar_url}
+              alt={`${profile.display_name}のアイコン`}
+              className="w-24 h-24 rounded-full object-cover border border-slate-200"
+            />
+          ) : (
+            <div className="w-24 h-24 rounded-full bg-slate-200 flex items-center justify-center text-3xl text-slate-500">
+              👩‍🏫
+            </div>
+          )}
+          <div>
+            <h1 className="text-2xl font-bold text-slate-900">{profile.display_name}</h1>
+            {profile.affiliation ? (
+              <p className="text-sm text-slate-600 mt-1">{profile.affiliation}</p>
+            ) : (
+              <p className="text-sm text-slate-400 mt-1">所属情報は未設定です</p>
+            )}
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-white shadow rounded-2xl p-5 space-y-3">
+        <h2 className="text-lg font-semibold text-slate-900">自己紹介</h2>
+        <p className="text-slate-700 whitespace-pre-wrap">
+          {profile.bio || 'この講師は自己紹介をまだ設定していません。'}
+        </p>
+        <p className="text-xs text-slate-500 text-right">
+          最終更新: {new Date(profile.updated_at).toLocaleString('ja-JP')}
+        </p>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
…ル直列化ヘルパーを実装（公開可能な項目のみ返す、検証・レートリミット含む）\n-  で教師アイコン・所属・自己紹介・最終更新日時を返すようにし、学生側で確認オーバーレイを表示（申請/キャンセル）に差し替え\n-  を既存リンクの状態別に処理するよう変更（active/pending は再作成せず 200、解除済みは  に復活させて再利用）\n-  /  更新処理を共通化し、ユニーク制約による 500 を防止\n- 生徒用に講師プロフィール返却用のシリアライザと API を追加（所有者かつ pending/active のときのみ安全な項目を返す）\n- フロントエンド: プレビュー確認オーバーレイの実装、既存登録ボタンを確認フローに差し替え、プロフィールの紐付け一覧で遷移・無効化表示を調整\n- 新規ページ  を追加し、公開情報のみを表示するスマホ向けレイアウトを実装\n\n(対象例: , , , )