### PR TITLE
fix: フォーカス学習を問題数選択モーダルへ変更、ユーティリティ追加、バックエンド修正

### DIFF
--- a/frontend/src/app/student/quiz/level/[collectionId]/page.tsx
+++ b/frontend/src/app/student/quiz/level/[collectionId]/page.tsx
@@ -5,20 +5,12 @@ import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { apiGet, apiPost } from '@/lib/api-utils';
 import type { Quiz, QuizCollection, QuizQuestion } from '@/types/quiz';
+import { buildFocusQuestionOptions, buildNumberOptions, FOCUS_MAX_LIMIT } from '@/lib/focus-utils';
 
 interface QuizRow {
   quiz: Quiz;
   questionCount: number;
 }
-
-const buildOptions = (min: number, max: number, step: number) => {
-  const list: number[] = [];
-  for (let v = min; v <= max; v += step) {
-    list.push(v);
-  }
-  if (list[list.length - 1] !== max) list.push(max);
-  return Array.from(new Set(list)).sort((a, b) => a - b);
-};
 
 export default function QuizLevelDetailPage() {
   const params = useParams<{ collectionId: string }>();
@@ -43,14 +35,12 @@ export default function QuizLevelDetailPage() {
   const totalQuestions = useMemo(() => (quizzes || []).reduce((sum, r) => sum + r.questionCount, 0), [quizzes]);
   const randomOptions = useMemo(() => {
     const max = Math.max(totalQuestions, 10);
-    return buildOptions(Math.min(10, max), max, 10);
+    return buildNumberOptions(Math.min(10, max), max, 10);
   }, [totalQuestions]);
   const focusTotal = focusIds.length;
   const focusOptions = useMemo(() => {
     if (focusTotal === 0) return [];
-    const min = focusTotal >= 10 ? 10 : 1;
-    const step = focusTotal >= 10 ? 5 : 1;
-    return buildOptions(min, focusTotal, step);
+    return buildFocusQuestionOptions(Math.min(focusTotal, FOCUS_MAX_LIMIT));
   }, [focusTotal]);
 
   useEffect(() => {

--- a/frontend/src/lib/focus-utils.ts
+++ b/frontend/src/lib/focus-utils.ts
@@ -1,0 +1,18 @@
+export const FOCUS_MAX_LIMIT = 100;
+
+export const buildNumberOptions = (min: number, max: number, step: number) => {
+  const list: number[] = [];
+  for (let v = min; v <= max; v += step) {
+    list.push(v);
+  }
+  if (list[list.length - 1] !== max) list.push(max);
+  return Array.from(new Set(list)).sort((a, b) => a - b);
+};
+
+export const buildFocusQuestionOptions = (availableCount: number) => {
+  const capped = Math.max(0, Math.min(availableCount, FOCUS_MAX_LIMIT));
+  if (capped === 0) return [];
+  const min = capped >= 10 ? 10 : 1;
+  const step = capped >= 10 ? 5 : 1;
+  return buildNumberOptions(min, capped, step);
+};


### PR DESCRIPTION
- ダッシュボードのフォーカス学習を「クイズに挑戦」ボタンと問題数選択モーダルへ変更（最大100問）
- 追加: frontend/src/lib/focus-utils.ts を作成しダッシュボードとレベル詳細で利用
- フロント: dashboard/page.tsx と level/[collectionId]/page.tsx を更新し /api/focus-quiz-sessions/ を呼ぶよう実装
- バックエンド: backend/quiz/views.py のフォーカスクイズ生成処理を修正し 500 を解消
- テスト未実施のためローカルで動作確認を推奨