### PR TITLE
fix: AvatarUploadViewで絶対URLを返すようにし、シリアライザでavatar_urlをリクエスト基準の絶対URLに変換

### DIFF
--- a/backend/quiz/serializers.py
+++ b/backend/quiz/serializers.py
@@ -27,6 +27,7 @@ class UserSerializer(serializers.ModelSerializer):
 
 class UserProfileSerializer(serializers.ModelSerializer):
     user = serializers.UUIDField(source="user_id", read_only=True)
+    avatar_url = serializers.SerializerMethodField()
 
     class Meta:
         model = models.UserProfile
@@ -39,6 +40,20 @@ class UserProfileSerializer(serializers.ModelSerializer):
             "updated_at",
         ]
         read_only_fields = ["user", "updated_at"]
+
+    def get_avatar_url(self, obj):
+        url = obj.avatar_url
+        if not url:
+            return None
+        if isinstance(url, str) and url.startswith(("http://", "https://")):
+            return url
+        request = self.context.get("request")
+        if request:
+            try:
+                return request.build_absolute_uri(url)
+            except Exception:
+                return url
+        return url
 
 
 class TeacherSerializer(serializers.ModelSerializer):
@@ -61,6 +76,8 @@ class TeacherSerializer(serializers.ModelSerializer):
 
 
 class TeacherProfileSerializer(serializers.ModelSerializer):
+    avatar_url = serializers.SerializerMethodField()
+
     class Meta:
         model = models.TeacherProfile
         fields = [
@@ -72,6 +89,20 @@ class TeacherProfileSerializer(serializers.ModelSerializer):
             "updated_at",
         ]
         read_only_fields = ["teacher", "updated_at"]
+
+    def get_avatar_url(self, obj):
+        url = obj.avatar_url
+        if not url:
+            return None
+        if isinstance(url, str) and url.startswith(("http://", "https://")):
+            return url
+        request = self.context.get("request")
+        if request:
+            try:
+                return request.build_absolute_uri(url)
+            except Exception:
+                return url
+        return url
 
 
 class TeacherWhitelistSerializer(serializers.ModelSerializer):

--- a/backend/quiz/views.py
+++ b/backend/quiz/views.py
@@ -105,6 +105,7 @@ class AvatarUploadView(APIView):
         filename = f"avatars/{request.user.id}/{uuid.uuid4()}{suffix}"
         saved_path = default_storage.save(filename, file)
         public_url = default_storage.url(saved_path)
+        absolute_url = request.build_absolute_uri(public_url)
 
         if upload_for == "teacher":
             if not is_teacher_whitelisted(request.user.email):
@@ -119,7 +120,7 @@ class AvatarUploadView(APIView):
             profile, _ = models.TeacherProfile.objects.get_or_create(teacher=teacher)
             profile.avatar_url = public_url
             profile.save(update_fields=["avatar_url"])
-            return Response({"avatar_url": public_url})
+            return Response({"avatar_url": absolute_url})
 
         profile, _ = models.UserProfile.objects.get_or_create(
             user=request.user,
@@ -127,7 +128,7 @@ class AvatarUploadView(APIView):
         )
         profile.avatar_url = public_url
         profile.save(update_fields=["avatar_url"])
-        return Response({"avatar_url": public_url})
+        return Response({"avatar_url": absolute_url})
 
 
 class TeacherViewSet(BaseModelViewSet):


### PR DESCRIPTION
- `AvatarUploadView` が相対パスを保持しつつ `request.build_absolute_uri()` で絶対URLを計算してレスポンスに含めるように変更（frontendで即時表示可能に）
- `UserProfileSerializer` / `TeacherProfileSerializer` のavatarフィールドを `SerializerMethodField` に差し替え、保存値が相対パスでもリクエスト情報を使って絶対URLに変換して返すように実装（既に絶対URLが保存されている場合はそのまま返す）
- 過去データとの互換性を保持しつつ、プロフィール取得APIから常にブラウザ到達可能なURLが返るよう修正