### PR TITLE
fix: /api/teacher/students のシリアライザに request コンテキストを渡すよう修正、Next.js に本番…

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -12,6 +12,21 @@ const nextConfig: NextConfig = {
     ignoreBuildErrors: true,
   },
   reactStrictMode: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: "http",
+        hostname: "localhost",
+        port: "8080",
+        pathname: "/media/**",
+      },
+      {
+        protocol: "https",
+        hostname: "quiz-backend-974259457412.asia-northeast1.run.app",
+        pathname: "/media/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
…/ローカルの /media を許可

- `TeacherStudentListSerializer` を使う箇所（一覧取得・表示名更新）に `context={"request": request}` を渡すよう変更し、`build_absolute_media_url` が確実に動作するように修正（avatar_url が常に絶対 URL で返る）
- `frontend/next.config.ts` の `remotePatterns` に本番バックエンド `quiz-backend-974259457412.asia-northeast1.run.app` とローカル `localhost:8080` の `/media/**` を追加し、Next/Image で外部メディアを直接表示できるように変更
- これにより `/teacher/students` を含む画面でアイコンが `/media/...` のままにならずブラウザで到達可能な URL を用いて表示されるようになります