### PR TITLE
chore: MEDIA_URL を常時 /media/ に固定し GCS の有効化を環境変数制御に変更、/media ルート配信とメディ…

### DIFF
--- a/backend/quiz/serializers.py
+++ b/backend/quiz/serializers.py
@@ -1,7 +1,9 @@
 """新スキーマ用シリアライザー"""
 
 from typing import Optional
+from urllib.parse import urljoin
 
+from django.conf import settings
 from django.http import HttpRequest
 from rest_framework import serializers
 
@@ -9,17 +11,15 @@ from . import models
 from .utils import is_teacher_whitelisted
 
 
-def build_absolute_media_url(request: Optional[HttpRequest], url: Optional[str]):
-    if not url:
+def build_absolute_media_url(request: Optional[HttpRequest], relative_path: Optional[str]):
+    if not relative_path:
         return None
-    if isinstance(url, str) and url.startswith(("http://", "https://")):
-        return url
-    if request:
-        try:
-            return request.build_absolute_uri(url)
-        except Exception:
-            return url
-    return url
+    if isinstance(relative_path, str) and relative_path.startswith(("http://", "https://")):
+        return relative_path
+    joined = urljoin(settings.MEDIA_URL, relative_path.lstrip("/"))
+    if request is None:
+        return joined
+    return request.build_absolute_uri(joined)
 
 
 class UserSerializer(serializers.ModelSerializer):

--- a/backend/quiz_backend/settings.py
+++ b/backend/quiz_backend/settings.py
@@ -147,7 +147,18 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 
 # Media files (user uploaded)
 MEDIA_URL = '/media/'
-MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+MEDIA_ROOT = BASE_DIR / 'media'
+USE_GCS_MEDIA = os.getenv('USE_GCS_MEDIA', '0') == '1'
+
+if USE_GCS_MEDIA:
+    if 'storages' not in INSTALLED_APPS:
+        INSTALLED_APPS.append('storages')
+    DEFAULT_FILE_STORAGE = 'storages.backends.gcloud.GoogleCloudStorage'
+    try:
+        GS_BUCKET_NAME = os.environ['GS_BUCKET_NAME']
+    except KeyError as exc:  # noqa: PERF203
+        raise RuntimeError('GS_BUCKET_NAME must be set when USE_GCS_MEDIA=1') from exc
+    GS_DEFAULT_ACL = None
 
 # Default primary key field type
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'

--- a/backend/quiz_backend/urls.py
+++ b/backend/quiz_backend/urls.py
@@ -3,13 +3,12 @@ URL configuration for quiz_backend project.
 """
 from django.contrib import admin
 from django.urls import path, include
-from django.conf import settings
-from django.conf.urls.static import static
+
+from quiz.views import media_serve
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/', include('quiz.urls')),
     path('accounts/', include('allauth.urls')),
+    path('media/<path:path>', media_serve, name='media'),
 ]
-
-urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,3 +15,5 @@ cryptography>=41.0
 google-auth>=2.23.0
 google-auth-oauthlib>=1.1.0
 Pillow>=10.0
+django-storages>=1.14
+google-cloud-storage>=2.18

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,5 +1,14 @@
 import type { NextConfig } from "next";
 
+const backendOrigin = process.env.NEXT_PUBLIC_BACKEND_ORIGIN ?? "http://localhost:8080";
+let backendUrl: URL;
+
+try {
+  backendUrl = new URL(backendOrigin);
+} catch {
+  backendUrl = new URL("http://localhost:8080");
+}
+
 const nextConfig: NextConfig = {
   // Temporarily ignore ESLint and TypeScript build errors inside Docker
   // so CI/development images can still produce `.next` artifacts.
@@ -15,15 +24,10 @@ const nextConfig: NextConfig = {
   images: {
     remotePatterns: [
       {
-        protocol: "http",
-        hostname: "localhost",
-        port: "8080",
+        protocol: backendUrl.protocol.replace(":", ""),
+        hostname: backendUrl.hostname,
         pathname: "/media/**",
-      },
-      {
-        protocol: "https",
-        hostname: "quiz-backend-974259457412.asia-northeast1.run.app",
-        pathname: "/media/**",
+        ...(backendUrl.port ? { port: backendUrl.port } : {}),
       },
     ],
   },


### PR DESCRIPTION
…アURL生成の統一

- `MEDIA_URL` を常に `/media/` として扱うように設定（`backend/quiz_backend/settings.py`）
- 環境変数 `USE_GCS_MEDIA=1` の場合のみ storages と GCS backend を有効化。`GS_BUCKET_NAME` 未設定なら起動時に例外を投げるように変更（運用でのバケット指定を必須化）
- `media/<path:path>` をルートに追加して `static()` 依存を排除し、Cloud Run 本番でも Django 経由で /media/** を配信可能に（`backend/quiz_backend/urls.py`）
- `build_absolute_media_url(request, ...)` ヘルパで返却 URL 生成を一本化し、シリアライザ/ビューでこれを使用するように統一（`backend/quiz/serializers.py`, `backend/quiz/views.py`）
- Cloud Run が非公開 GCS をプロキシできるように `media_serve` ビューを追加して `FileResponse` で安全に配信（パス検証・Cache-Control あり、`backend/quiz/views.py`）
- フロントエンドの Next.js 設定を `NEXT_PUBLIC_BACKEND_ORIGIN` に合わせて画像ホストを1パターンで解決するよう調整（`frontend/next.config.ts`）