### PR TITLE
feat: 教師プロフィールヘッダーを縦並びレイアウトに差し替え、propsを更新

### DIFF
--- a/frontend/src/app/teacher/profile/page.tsx
+++ b/frontend/src/app/teacher/profile/page.tsx
@@ -4,7 +4,9 @@ import { useEffect, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import { apiGet, apiPost, apiPatch } from '@/lib/api-utils';
 import type { TeacherProfile, ApiUser, Teacher } from '@/types/quiz';
-import { UserCircleIcon, CheckCircleIcon, XCircleIcon } from '@heroicons/react/24/outline';
+import { CheckCircleIcon, XCircleIcon } from '@heroicons/react/24/outline';
+import TeacherProfileHeader from '@/components/teacher/TeacherProfileHeader';
+import TeacherAccountCard from '@/components/teacher/TeacherAccountCard';
 
 export default function TeacherProfilePage() {
   const { data: session } = useSession();
@@ -152,216 +154,145 @@ export default function TeacherProfilePage() {
     }
   };
 
+  const displayNameValue = formData.display_name || user?.email || '未設定';
+  const affiliationValue = formData.affiliation || '';
+  const selfIntroValue = formData.bio || profile?.bio || '';
+  const formattedUpdatedAt = profile?.updated_at
+    ? new Date(profile.updated_at).toLocaleString('ja-JP', { dateStyle: 'medium', timeStyle: 'short' })
+    : '-';
+  const formattedCreatedAt = user?.created_at
+    ? new Date(user.created_at).toLocaleDateString('ja-JP', { year: 'numeric', month: 'short', day: 'numeric' })
+    : '-';
+  const roleLabel = '講師（ホワイトリスト登録済み）';
+
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="animate-spin h-10 w-10 border-4 border-indigo-500 rounded-full border-t-transparent"></div>
+      <div className="flex min-h-screen items-center justify-center bg-slate-50">
+        <div className="h-10 w-10 animate-spin rounded-full border-4 border-indigo-500 border-t-transparent"></div>
       </div>
     );
   }
 
   return (
-    <div className="max-w-4xl mx-auto space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold text-slate-900">講師プロフィール</h1>
-          <p className="text-slate-600 mt-2">あなたの情報を管理します</p>
-        </div>
-        {!editing && (
-          <button
-            onClick={() => setEditing(true)}
-            className="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors shadow-lg"
-          >
-            編集
-          </button>
-        )}
-      </div>
-
-      {/* Alerts */}
-      {error && (
-        <div className="bg-red-50 border border-red-200 text-red-800 px-4 py-3 rounded-lg flex items-center gap-2">
-          <XCircleIcon className="h-5 w-5" />
-          {error}
-        </div>
-      )}
-      {success && (
-        <div className="bg-green-50 border border-green-200 text-green-800 px-4 py-3 rounded-lg flex items-center gap-2">
-          <CheckCircleIcon className="h-5 w-5" />
-          {success}
-        </div>
-      )}
-
-      {/* Profile Card */}
-      <div className="bg-white rounded-xl shadow-lg border border-slate-200 overflow-hidden">
-        <div className="bg-gradient-to-r from-indigo-500 to-blue-500 h-32"></div>
-        <div className="px-8 pb-8">
-          {/* Avatar */}
-          <div className="flex items-end -mt-16 mb-6">
-            {avatarPreview ? (
-              <img
-                src={avatarPreview}
-                alt="Avatar"
-                className="w-32 h-32 rounded-full border-4 border-white shadow-lg object-cover bg-white"
-              />
-            ) : (
-              <div className="w-32 h-32 rounded-full border-4 border-white shadow-lg bg-slate-200 flex items-center justify-center">
-                <UserCircleIcon className="w-20 h-20 text-slate-400" />
-              </div>
-            )}
-            <div className="ml-6 pb-2">
-              <h2 className="text-2xl font-bold text-slate-900">
-                {formData.display_name || user?.email || '未設定'}
-              </h2>
-              {formData.affiliation && (
-                <p className="text-slate-600 mt-1">{formData.affiliation}</p>
-              )}
+    <div className="min-h-screen bg-slate-50">
+      <main className="mx-auto max-w-5xl px-4 py-8 md:px-6 md:py-10">
+        <div className="space-y-8">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Teacher Profile</p>
+              <h1 className="text-2xl font-bold text-slate-900 md:text-3xl">講師プロフィール</h1>
+              <p className="mt-2 text-sm text-slate-600">公開情報とアカウント情報をここで管理します。</p>
             </div>
+            {!editing && (
+              <button
+                onClick={() => setEditing(true)}
+                className="inline-flex items-center justify-center rounded-full bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-indigo-200 transition hover:bg-indigo-700"
+              >
+                プロフィールを編集
+              </button>
+            )}
           </div>
 
-          {editing ? (
-            /* Edit Form */
-            <form onSubmit={handleSave} className="space-y-6">
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <div>
-                  <label className="block text-sm font-medium text-slate-700 mb-1">
-                    表示名
-                  </label>
-                  <input
-                    type="text"
-                    value={formData.display_name}
-                    onChange={(e) => setFormData({ ...formData, display_name: e.target.value })}
-                    className="w-full px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
-                    placeholder="山田 太郎"
-                  />
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-slate-700 mb-1">
-                    所属（団体名）
-                  </label>
-                  <input
-                    type="text"
-                    value={formData.affiliation}
-                    onChange={(e) => setFormData({ ...formData, affiliation: e.target.value })}
-                    className="w-full px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
-                    placeholder="○○大学 / ○○高校"
-                  />
-                </div>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-slate-700 mb-1">プロフィール画像</label>
-                <div className="flex items-center gap-3">
-                  <label className="px-4 py-2 border border-slate-300 rounded-md bg-slate-50 text-sm font-semibold text-slate-800 cursor-pointer hover:bg-slate-100">
-                    画像を選択 (png/jpeg)
-                    <input type="file" accept="image/png,image/jpeg" className="hidden" onChange={handleAvatarUpload} />
-                  </label>
-                  {avatarPreview && <span className="text-xs text-slate-500">更新予定</span>}
-                </div>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-slate-700 mb-1">
-                  自己紹介
-                </label>
-                <textarea
-                  value={formData.bio}
-                  onChange={(e) => setFormData({ ...formData, bio: e.target.value })}
-                  className="w-full px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
-                  rows={5}
-                  placeholder="あなたの自己紹介を入力してください"
-                />
-              </div>
-
-              <div className="flex gap-3 pt-4">
-                <button
-                  type="submit"
-                  disabled={saving}
-                  className="flex-1 bg-indigo-600 text-white px-4 py-2.5 rounded-lg hover:bg-indigo-700 transition-colors font-medium disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  {saving ? '保存中...' : '保存'}
-                </button>
-                <button
-                  type="button"
-                  onClick={handleCancel}
-                  disabled={saving}
-                  className="flex-1 bg-slate-200 text-slate-700 px-4 py-2.5 rounded-lg hover:bg-slate-300 transition-colors font-medium disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  キャンセル
-                </button>
-              </div>
-            </form>
-          ) : (
-            /* View Mode */
-            <div className="space-y-6">
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <div>
-                  <h3 className="text-sm font-medium text-slate-500 mb-1">メールアドレス</h3>
-                  <p className="text-slate-900">{user?.email || '-'}</p>
-                </div>
-
-                <div>
-                  <h3 className="text-sm font-medium text-slate-500 mb-1">表示名</h3>
-                  <p className="text-slate-900">{formData.display_name || '未設定'}</p>
-                </div>
-
-                <div>
-                  <h3 className="text-sm font-medium text-slate-500 mb-1">所属</h3>
-                  <p className="text-slate-900">{formData.affiliation || '未設定'}</p>
-                </div>
-
-                <div>
-                  <h3 className="text-sm font-medium text-slate-500 mb-1">更新日</h3>
-                  <p className="text-slate-900">
-                    {profile?.updated_at 
-                      ? new Date(profile.updated_at).toLocaleString('ja-JP')
-                      : '-'
-                    }
-                  </p>
-                </div>
-              </div>
-
-              {formData.bio && (
-                <div>
-                  <h3 className="text-sm font-medium text-slate-500 mb-1">自己紹介</h3>
-                  <p className="text-slate-900 whitespace-pre-wrap">{formData.bio}</p>
-                </div>
-              )}
+          {error && (
+            <div className="flex items-center gap-2 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
+              <XCircleIcon className="h-5 w-5" />
+              {error}
             </div>
           )}
-        </div>
-      </div>
+          {success && (
+            <div className="flex items-center gap-2 rounded-2xl border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-800">
+              <CheckCircleIcon className="h-5 w-5" />
+              {success}
+            </div>
+          )}
 
-      {/* Account Info */}
-      <div className="bg-white rounded-xl shadow-lg border border-slate-200 p-6">
-        <h3 className="text-lg font-semibold text-slate-900 mb-4">アカウント情報</h3>
-        <div className="space-y-3 text-sm">
-          <div className="flex justify-between">
-            <span className="text-slate-600">ユーザーID</span>
-            <span className="text-slate-900 font-mono">{user?.user_id}</span>
-          </div>
-          <div className="flex justify-between">
-            <span className="text-slate-600">認証プロバイダー</span>
-            <span className="text-slate-900">{user?.oauth_provider || '-'}</span>
-          </div>
-          <div className="flex justify-between">
-            <span className="text-slate-600">権限</span>
-            <span className="px-2 py-1 rounded text-xs font-medium bg-indigo-100 text-indigo-800">
-              講師（ホワイトリスト登録済み）
-            </span>
-          </div>
-          <div className="flex justify-between">
-            <span className="text-slate-600">登録日</span>
-            <span className="text-slate-900">
-              {user?.created_at 
-                ? new Date(user.created_at).toLocaleDateString('ja-JP')
-                : '-'
-              }
-            </span>
-          </div>
+          <TeacherProfileHeader
+            avatarUrl={avatarPreview}
+            displayName={displayNameValue}
+            affiliation={affiliationValue}
+            email={user?.email || '-'}
+            updatedAtLabel={formattedUpdatedAt}
+            selfIntro={selfIntroValue}
+          />
+
+          {editing && (
+            <section className="rounded-2xl bg-white px-6 py-6 shadow-md shadow-slate-200 md:px-8">
+              <h2 className="text-base font-semibold text-slate-900">プロフィールを編集</h2>
+              <form onSubmit={handleSave} className="mt-4 space-y-6">
+                <div className="grid gap-6 md:grid-cols-2">
+                  <div>
+                    <label className="block text-sm font-medium text-slate-700">表示名</label>
+                    <input
+                      type="text"
+                      value={formData.display_name}
+                      onChange={(e) => setFormData({ ...formData, display_name: e.target.value })}
+                      className="mt-2 w-full rounded-lg border border-slate-300 px-4 py-2 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                      placeholder="山田 太郎"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-slate-700">所属（団体名）</label>
+                    <input
+                      type="text"
+                      value={formData.affiliation}
+                      onChange={(e) => setFormData({ ...formData, affiliation: e.target.value })}
+                      className="mt-2 w-full rounded-lg border border-slate-300 px-4 py-2 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                      placeholder="○○大学 / ○○高校"
+                    />
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-slate-700">プロフィール画像</label>
+                  <div className="mt-2 flex items-center gap-3">
+                    <label className="cursor-pointer rounded-lg border border-dashed border-slate-300 bg-slate-50 px-4 py-2 text-sm font-semibold text-slate-800 hover:bg-slate-100">
+                      画像を選択 (png/jpeg)
+                      <input type="file" accept="image/png,image/jpeg" className="hidden" onChange={handleAvatarUpload} />
+                    </label>
+                    {avatarPreview && <span className="text-xs text-slate-500">更新予定</span>}
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-slate-700">自己紹介</label>
+                  <textarea
+                    value={formData.bio}
+                    onChange={(e) => setFormData({ ...formData, bio: e.target.value })}
+                    className="mt-2 w-full rounded-lg border border-slate-300 px-4 py-3 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                    rows={5}
+                    placeholder="あなたの自己紹介を入力してください"
+                  />
+                </div>
+
+                <div className="flex flex-col gap-3 pt-2 md:flex-row">
+                  <button
+                    type="submit"
+                    disabled={saving}
+                    className="inline-flex flex-1 items-center justify-center rounded-full bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-lg shadow-indigo-200 transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {saving ? '保存中...' : '保存'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleCancel}
+                    disabled={saving}
+                    className="inline-flex flex-1 items-center justify-center rounded-full bg-slate-200 px-4 py-2.5 text-sm font-semibold text-slate-700 transition hover:bg-slate-300 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    キャンセル
+                  </button>
+                </div>
+              </form>
+            </section>
+          )}
+
+          <TeacherAccountCard
+            userId={user?.user_id}
+            provider={user?.oauth_provider}
+            roleLabel={roleLabel}
+            createdAt={formattedCreatedAt}
+          />
         </div>
-      </div>
+      </main>
     </div>
   );
 }

--- a/frontend/src/components/teacher/TeacherProfileHeader.tsx
+++ b/frontend/src/components/teacher/TeacherProfileHeader.tsx
@@ -1,0 +1,88 @@
+import Image from "next/image";
+
+type Props = {
+  avatarUrl?: string | null;
+  displayName: string;
+  affiliation?: string | null;
+  email: string;
+  updatedAtLabel: string;
+  selfIntro?: string | null;
+};
+
+export function TeacherProfileHeader({
+  avatarUrl,
+  displayName,
+  affiliation,
+  email,
+  updatedAtLabel,
+  selfIntro,
+}: Props) {
+  const hasAvatar = Boolean(avatarUrl);
+
+  return (
+    <section className="overflow-hidden rounded-3xl bg-white shadow-lg shadow-slate-200">
+      <div className="h-32 bg-gradient-to-r from-indigo-500 via-sky-500 to-cyan-400" />
+      <div className="px-6 pb-6 pt-0 md:px-8 md:pb-8">
+        <div className="-mt-16 flex items-end gap-4">
+          <div className="h-28 w-28 shrink-0 rounded-full border-4 border-white bg-white shadow-md md:h-32 md:w-32">
+            {hasAvatar && avatarUrl ? (
+              <Image
+                src={avatarUrl}
+                alt="プロフィール画像"
+                width={128}
+                height={128}
+                className="h-full w-full rounded-full object-cover"
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center rounded-full bg-slate-100 text-xs font-medium text-slate-400">
+                画像未設定
+              </div>
+            )}
+          </div>
+          <div className="pb-2">
+            <div className="text-xl font-semibold text-slate-900 md:text-2xl">
+              {displayName || "未設定"}
+            </div>
+            {affiliation && (
+              <div className="mt-1 text-sm text-slate-600">{affiliation}</div>
+            )}
+          </div>
+        </div>
+
+        <div className="mt-6 grid gap-4 text-sm text-slate-700 md:grid-cols-2">
+          <div>
+            <div className="text-xs font-medium uppercase tracking-wide text-slate-400">
+              メールアドレス
+            </div>
+            <div className="mt-0.5 break-all">{email || "-"}</div>
+          </div>
+          <div>
+            <div className="text-xs font-medium uppercase tracking-wide text-slate-400">
+              表示名
+            </div>
+            <div className="mt-0.5">{displayName || "未設定"}</div>
+          </div>
+          <div>
+            <div className="text-xs font-medium uppercase tracking-wide text-slate-400">
+              更新日
+            </div>
+            <div className="mt-0.5">{updatedAtLabel || "-"}</div>
+          </div>
+        </div>
+
+        <div className="mt-6 border-t border-slate-100 pt-4">
+          <div className="text-xs font-medium uppercase tracking-wide text-slate-400">
+            自己紹介
+          </div>
+          <p className="mt-1 whitespace-pre-line text-sm leading-relaxed text-slate-700">
+            {selfIntro && selfIntro.trim().length > 0
+              ? selfIntro
+              : "自己紹介はまだ入力されていません。"}
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default TeacherProfileHeader;


### PR DESCRIPTION
- `TeacherProfileHeader` をアバター→メタ情報→自己紹介 の縦並び構成に差し替え（未設定時は小さな「画像未設定」バッジ表示）
- メール/表示名/更新日ラベルをグラデーション下にまとめるレイアウトに変更
- 呼び出し元 `frontend/src/app/teacher/profile/page.tsx` 側でヘッダーへ渡す props を `email` と `updatedAtLabel` に合わせて更新（`user?.email || -` を利用）